### PR TITLE
Include verify json_template to exit gracefully

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "name": "metadata-import-dicom",
   "label": "Metadata Import and Validation: DICOM",
   "description": "Metadata Import and Validation for DICOM files. This Gear will parse, import, and validate DICOM header metadata. Those metadata are added to the input file's metadata object (<inputFile>.info). A metadata validation template must be provided as input to the gear, which the gear will use to validate the DICOM metadata. Data which fail this validation will be tagged (with 'error') and an error file will be generated and written to the input container.",
-  "version": "1.2.3",
+  "version": "1.3.1",
   "custom": {
     "gear-builder": {
       "category": "converter",
-      "image": "flywheel/metadata-import-dicom:1.2.3"
+      "image": "flywheel/metadata-import-dicom:1.3.1"
     },
     "flywheel": {
       "suite": "Metadata Import and Validation"

--- a/run.py
+++ b/run.py
@@ -302,6 +302,14 @@ def validate_against_template(input_dict, template):
     :param error_log_path: the path to which to write error log JSON
     :return: validation_errors, an object containing information on validation errors
     """
+    try:
+        jsonschema.Draft7Validator.check_schema(template)
+    except Exception as e:
+        log.fatal(
+            'The json_template is invalid. Please make the correction and try again.'
+        )
+        log.exception(e)
+
     # Initialize json schema validator
     validator = jsonschema.Draft7Validator(template)
     # Initialize list object for storing validation errors
@@ -418,7 +426,7 @@ def check_missing_slices(df, this_sequence):
                 else:
                     locations = []
                     log.warning("'ImagePositionPatient' string format error, cannot check for missing slices!")
-                    break;
+                    break
 
         else:
             log.warning("'ImageOrientationPatient' string format error, cannot check for missing slices!")

--- a/run.py
+++ b/run.py
@@ -309,6 +309,7 @@ def validate_against_template(input_dict, template):
             'The json_template is invalid. Please make the correction and try again.'
         )
         log.exception(e)
+        os.sys.exit(1)
 
     # Initialize json schema validator
     validator = jsonschema.Draft7Validator(template)


### PR DESCRIPTION
Included a try/except block to verify that the json_template was formatted correctly.
For example, if the sub-key 'pattern' is given anything but a string it will error and exit 1.

Version patch incremented to 1.3.1