### PR TITLE
fix info extraction on sequence/rtstruct [GEAR-232]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ notebooks/error.log.json
 notebooks/A.zip
 output
 __pycache__
+.coverage
+.htmlcov

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "name": "metadata-import-dicom",
   "label": "Metadata Import and Validation: DICOM",
   "description": "Metadata Import and Validation for DICOM files. This Gear will parse, import, and validate DICOM header metadata. Those metadata are added to the input file's metadata object (<inputFile>.info). A metadata validation template must be provided as input to the gear, which the gear will use to validate the DICOM metadata. Data which fail this validation will be tagged (with 'error') and an error file will be generated and written to the input container.",
-  "version": "2.1.3-dev12",
+  "version": "2.1.3",
   "custom": {
     "gear-builder": {
       "category": "converter",
-      "image": "flywheel/metadata-import-dicom:2.1.3-dev12"
+      "image": "flywheel/metadata-import-dicom:2.1.3"
     },
     "flywheel": {
       "suite": "Metadata Import and Validation"

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "name": "metadata-import-dicom",
   "label": "Metadata Import and Validation: DICOM",
   "description": "Metadata Import and Validation for DICOM files. This Gear will parse, import, and validate DICOM header metadata. Those metadata are added to the input file's metadata object (<inputFile>.info). A metadata validation template must be provided as input to the gear, which the gear will use to validate the DICOM metadata. Data which fail this validation will be tagged (with 'error') and an error file will be generated and written to the input container.",
-  "version": "2.1.2",
+  "version": "2.1.3-dev12",
   "custom": {
     "gear-builder": {
       "category": "converter",
-      "image": "flywheel/metadata-import-dicom:2.1.2"
+      "image": "flywheel/metadata-import-dicom:2.1.3-dev12"
     },
     "flywheel": {
       "suite": "Metadata Import and Validation"

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "name": "metadata-import-dicom",
   "label": "Metadata Import and Validation: DICOM",
   "description": "Metadata Import and Validation for DICOM files. This Gear will parse, import, and validate DICOM header metadata. Those metadata are added to the input file's metadata object (<inputFile>.info). A metadata validation template must be provided as input to the gear, which the gear will use to validate the DICOM metadata. Data which fail this validation will be tagged (with 'error') and an error file will be generated and written to the input container.",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "custom": {
     "gear-builder": {
       "category": "converter",
-      "image": "flywheel/metadata-import-dicom:2.1.3"
+      "image": "flywheel/metadata-import-dicom:2.2.0"
     },
     "flywheel": {
       "suite": "Metadata Import and Validation"

--- a/run.py
+++ b/run.py
@@ -11,6 +11,7 @@ import tzlocal
 import logging
 import zipfile
 import datetime
+import shutil
 import argparse
 import nibabel
 import pandas as pd
@@ -212,32 +213,38 @@ def format_string(in_string):
 
 
 def get_seq_data(sequence, ignore_keys):
-    seq_dict = {}
+    res = []
     for seq in sequence:
-        for s_key in seq.dir():
-            s_val = getattr(seq, s_key, '')
-            if type(s_val) is pydicom.uid.UID or s_key in ignore_keys:
+        seq_dict = {}
+        for k, v in seq.items():
+            if not hasattr(v, 'keyword') or \
+                    (hasattr(v, 'keyword') and v.keyword in ignore_keys) or \
+                    (hasattr(v, 'keyword') and not v.keyword):  # keyword of type "" for unknown tags
                 continue
-
-            if type(s_val) == pydicom.sequence.Sequence:
-                _seq = get_seq_data(s_val, ignore_keys)
-                seq_dict[s_key] = _seq
-                continue
-
-            if type(s_val) == str:
-                s_val = format_string(s_val)
+            kw = v.keyword
+            if isinstance(v.value, pydicom.sequence.Sequence):
+                seq_dict[kw] = get_seq_data(v, ignore_keys)
+            elif isinstance(v.value, str):
+                seq_dict[kw] = format_string(v.value)
             else:
-                s_val = assign_type(s_val)
-
-            if s_val:
-                seq_dict[s_key] = s_val
-    return seq_dict
+                seq_dict[kw] = assign_type(v.value)
+        res.append(seq_dict)
+    return res
 
 
 def get_pydicom_header(dcm):
     # Extract the header values
+    dcm.decode()
     header = {}
-    exclude_tags = ['[Unknown]', 'PixelData', 'Pixel Data',  '[User defined data]', '[Protocol Data Block (compressed)]', '[Histogram tables]', '[Unique image iden]']
+    exclude_tags = ['[Unknown]',
+                    'PixelData',
+                    'Pixel Data',
+                    '[User defined data]',
+                    '[Protocol Data Block (compressed)]',
+                    '[Histogram tables]',
+                    '[Unique image iden]',
+                    'ContourData',
+                    ]
     tags = dcm.dir()
     for tag in tags:
         try:
@@ -252,7 +259,7 @@ def get_pydicom_header(dcm):
                 else:
                     log.debug('No value found for tag: ' + tag)
 
-            if type(dcm.get(tag)) == pydicom.sequence.Sequence:
+            if (tag not in exclude_tags) and type(dcm.get(tag)) == pydicom.sequence.Sequence:
                 seq_data = get_seq_data(dcm.get(tag), exclude_tags)
                 # Check that the sequence is not empty
                 if seq_data:

--- a/run.py
+++ b/run.py
@@ -212,6 +212,15 @@ def format_string(in_string):
 
 
 def get_seq_data(sequence, ignore_keys):
+    """Return list of nested dictionaries matching sequence
+
+    Args:
+        sequence (pydicom.Sequence): A pydicom sequence
+        ignore_keys (list): List of keys to ignore
+
+    Returns:
+        (list): list of nested dictionary matching sequence
+    """
     res = []
     for seq in sequence:
         seq_dict = {}
@@ -233,7 +242,7 @@ def get_seq_data(sequence, ignore_keys):
 
 def get_pydicom_header(dcm):
     # Extract the header values
-    dcm.decode()
+    dcm.decode()   # used for the side effect of loading all dcm tags in memory
     header = {}
     exclude_tags = ['[Unknown]',
                     'PixelData',
@@ -789,6 +798,6 @@ if __name__ == '__main__':
         template.update(import_template)
     json_template = template.copy()
 
-    metadatafile = dicom_to_json(dicom_filepath, output_folder, timezone, json_template, force_dicom_read)
+    metadatafile = dicom_to_json(dicom_filepath, output_folder, timezone, json_template, force=force_dicom_read)
     if os.path.isfile(metadatafile):
         os.sys.exit(0)

--- a/run.py
+++ b/run.py
@@ -11,7 +11,6 @@ import tzlocal
 import logging
 import zipfile
 import datetime
-import shutil
 import argparse
 import nibabel
 import pandas as pd

--- a/tests/unit_tests/test_dicom_to_json.py
+++ b/tests/unit_tests/test_dicom_to_json.py
@@ -2,10 +2,11 @@ import os
 import tempfile
 
 import pydicom
+import copy
 
 from pydicom.data import get_testdata_files
 
-from run import dicom_to_json, validate_timezone
+from run import dicom_to_json, validate_timezone, get_seq_data
 
 
 def test_dicom_to_json_no_patientname():
@@ -19,3 +20,26 @@ def test_dicom_to_json_no_patientname():
 
         metadata_path = dicom_to_json(temp_path, tempdir, time_zone, {})
         assert os.path.isfile(metadata_path)
+
+
+def test_get_seq_data():
+    test_dicom_path = get_testdata_files('liver.dcm')[0]
+    dcm = pydicom.read_file(test_dicom_path)
+    dcm.decode()
+    res = get_seq_data(dcm.get('DimensionIndexSequence'), [])
+    assert isinstance(res, list)
+    assert len(res) == 2
+    assert 'DimensionOrganizationUID' in res[0]
+    assert 'DimensionOrganizationUID' in res[1]
+
+    # testing ignore_key filter
+    res = get_seq_data(dcm.get('DimensionIndexSequence'), ['DimensionOrganizationUID'])
+    assert 'DimensionOrganizationUID' not in res[0]
+
+    # testing recursivity
+    dcm = pydicom.read_file(test_dicom_path)
+    dcm.decode()
+    sequence = pydicom.Sequence()
+    dcm['DimensionIndexSequence'][0].add_new(dcm['DimensionIndexSequence'].tag, 'SQ', copy.deepcopy(dcm.get('DimensionIndexSequence')))
+    res = get_seq_data(dcm.get('DimensionIndexSequence'), [])
+    assert 'DimensionOrganizationUID' in res[0]['DimensionIndexSequence'][0]

--- a/tests/unit_tests/test_dicom_to_json.py
+++ b/tests/unit_tests/test_dicom_to_json.py
@@ -18,7 +18,7 @@ def test_dicom_to_json_no_patientname():
         temp_path = os.path.join(tempdir, os.path.basename(test_dicom_path))
         dcm.save_as(temp_path)
 
-        metadata_path = dicom_to_json(temp_path, tempdir, time_zone, {})
+        metadata_path = dicom_to_json(zip_file_path=temp_path, outbase=tempdir, timezone=time_zone, json_template={})
         assert os.path.isfile(metadata_path)
 
 

--- a/tests/unit_tests/test_dicom_to_json.py
+++ b/tests/unit_tests/test_dicom_to_json.py
@@ -17,5 +17,5 @@ def test_dicom_to_json_no_patientname():
         temp_path = os.path.join(tempdir, os.path.basename(test_dicom_path))
         dcm.save_as(temp_path)
 
-        metadata_path = dicom_to_json(zip_file_path=temp_path, outbase=tempdir, timezone=time_zone)
+        metadata_path = dicom_to_json(temp_path, tempdir, time_zone, {})
         assert os.path.isfile(metadata_path)


### PR DESCRIPTION
Fix issue on metadata extraction for Sequence element:

* force dcm to memory using decode()
* fix get_seq_data()
* add ContourData to exclude_tags (keeping it leads to 10Mb .metadata file, froze the log UI and crash the gear)
* exclude unknown tag from metadata (e.g. empty keyword)
* version up