### PR TITLE
GEAR-253, GEAR-249 fix logic for df columns and validate input files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ notebooks/A.zip
 output
 __pycache__
 .coverage
-.htmlcov
+htmlcov

--- a/tests/unit_tests/test_dicom_archive.py
+++ b/tests/unit_tests/test_dicom_archive.py
@@ -1,0 +1,38 @@
+import tempfile
+import os
+import pathlib
+import zipfile
+
+import pytest
+from pydicom.data import get_testdata_files
+
+from utils.dicom.dicom_archive import DicomArchive
+
+
+def test_dicom_archive_class_validate():
+
+    test_dicom_path = get_testdata_files('MR_small.dcm')[0]
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Test valid DICOM
+        dicom_archive = DicomArchive(zip_path=test_dicom_path, extract_dir=temp_dir, validate=True)
+        assert dicom_archive.dataset
+
+        # Test file doesn't exist
+        with pytest.raises(FileNotFoundError) as err:
+            assert DicomArchive(zip_path=os.path.join(temp_dir, 'DoesntExist'), extract_dir=temp_dir, validate=True)
+
+        # Test empty archive
+        with pytest.raises(RuntimeError) as err:
+            zip_path = os.path.join(temp_dir, 'empty_zip.zip')
+
+            with zipfile.ZipFile(zip_path, 'w') as zip_obj:
+                pass
+            assert DicomArchive(zip_path, extract_dir=temp_dir, validate=True)
+
+        # Test non-dicom
+        not_dicom_path = pathlib.Path(temp_dir)/'empty_file.txt'
+        not_dicom_path.touch()
+        not_dicom_path.write_text('SPAM')
+        with pytest.raises(RuntimeError) as err:
+            assert DicomArchive(not_dicom_path, extract_dir=temp_dir, validate=True)
+        assert 'failed to parse DICOMs' in str(err.value)

--- a/tests/unit_tests/test_dicom_to_json.py
+++ b/tests/unit_tests/test_dicom_to_json.py
@@ -43,3 +43,4 @@ def test_get_seq_data():
     dcm['DimensionIndexSequence'][0].add_new(dcm['DimensionIndexSequence'].tag, 'SQ', copy.deepcopy(dcm.get('DimensionIndexSequence')))
     res = get_seq_data(dcm.get('DimensionIndexSequence'), [])
     assert 'DimensionOrganizationUID' in res[0]['DimensionIndexSequence'][0]
+


### PR DESCRIPTION
Column logic was incorrect for checking that all columns were in the DataFrame which was leading to exceptions in Genentech's check_missing_slices function. Gear also now validates that there are DICOM files to parsed before actually attempting to parse them (Exception raised if input doesn't exist, pydicom did not generate a FileDataset, archive is empty, etc.) so that users are not confused by the exceptions downstream. 