### PR TITLE
Gear 703 rounding hotfix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "name": "metadata-import-dicom",
   "label": "Metadata Import and Validation: DICOM",
   "description": "Metadata Import and Validation for DICOM files. This Gear will parse, import, and validate DICOM header metadata. Those metadata are added to the input file's metadata object (<inputFile>.info). A metadata validation template must be provided as input to the gear, which the gear will use to validate the DICOM metadata. Data which fail this validation will be tagged (with 'error') and an error file will be generated and written to the input container.",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "custom": {
     "gear-builder": {
       "category": "converter",
-      "image": "flywheel/metadata-import-dicom:2.8.1"
+      "image": "flywheel/metadata-import-dicom:2.8.2"
     },
     "flywheel": {
       "suite": "Metadata Import and Validation"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-mock
 pandas
 numpy

--- a/tests/unit_tests/test_dicom_archive.py
+++ b/tests/unit_tests/test_dicom_archive.py
@@ -36,3 +36,7 @@ def test_dicom_archive_class_validate():
         with pytest.raises(RuntimeError) as err:
             assert DicomArchive(not_dicom_path, extract_dir=temp_dir, validate=True)
         assert 'failed to parse DICOMs' in str(err.value)
+
+@pytest.mark.parametrize('raw,exp',[(-.0365001,-.036),[-.036,-.036]])
+def test_contains_localizer_round(raw,exp):
+    assert DicomArchive._apply_rounding([raw]) == (exp,)

--- a/tests/unit_tests/test_dicom_archive.py
+++ b/tests/unit_tests/test_dicom_archive.py
@@ -1,59 +1,79 @@
-import tempfile
-import numpy as np
 import os
 import pathlib
+import tempfile
 import zipfile
+from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from pydicom.data import get_testdata_files
 
 from utils.dicom.dicom_archive import DicomArchive
-from unittest.mock import MagicMock
 
 
 def test_dicom_archive_class_validate():
 
-    test_dicom_path = get_testdata_files('MR_small.dcm')[0]
+    test_dicom_path = get_testdata_files("MR_small.dcm")[0]
     with tempfile.TemporaryDirectory() as temp_dir:
         # Test valid DICOM
-        dicom_archive = DicomArchive(zip_path=test_dicom_path, extract_dir=temp_dir, validate=True)
+        dicom_archive = DicomArchive(
+            zip_path=test_dicom_path, extract_dir=temp_dir, validate=True
+        )
         assert dicom_archive.dataset
 
         # Test file doesn't exist
         with pytest.raises(FileNotFoundError) as err:
-            assert DicomArchive(zip_path=os.path.join(temp_dir, 'DoesntExist'), extract_dir=temp_dir, validate=True)
+            assert DicomArchive(
+                zip_path=os.path.join(temp_dir, "DoesntExist"),
+                extract_dir=temp_dir,
+                validate=True,
+            )
 
         # Test empty archive
         with pytest.raises(RuntimeError) as err:
-            zip_path = os.path.join(temp_dir, 'empty_zip.zip')
+            zip_path = os.path.join(temp_dir, "empty_zip.zip")
 
-            with zipfile.ZipFile(zip_path, 'w') as zip_obj:
+            with zipfile.ZipFile(zip_path, "w") as zip_obj:
                 pass
             assert DicomArchive(zip_path, extract_dir=temp_dir, validate=True)
 
         # Test non-dicom
-        not_dicom_path = pathlib.Path(temp_dir)/'empty_file.txt'
+        not_dicom_path = pathlib.Path(temp_dir) / "empty_file.txt"
         not_dicom_path.touch()
-        not_dicom_path.write_text('SPAM')
+        not_dicom_path.write_text("SPAM")
         with pytest.raises(RuntimeError) as err:
             assert DicomArchive(not_dicom_path, extract_dir=temp_dir, validate=True)
-        assert 'failed to parse DICOMs' in str(err.value)
+        assert "failed to parse DICOMs" in str(err.value)
 
 
-im_arr = [[0.9989550114, 0.04570378363, 0, 0, 0, -1], [0.9989550114, 0.04570382088, 0, 0, 0, -1], [0.9989550114, 0.04570381716, 0, 0, 0, -1], [0.9989550114, 0.04570382088, 0, 0, 0, -1],[1, 0, 0, 0, 1, 0]]
-out = [[-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [0.001, -0.037, 0.0, 0.0, 0.8, 0.8]]
+im_arr = [
+    [0.9989550114, 0.04570378363, 0, 0, 0, -1],
+    [0.9989550114, 0.04570382088, 0, 0, 0, -1],
+    [0.9989550114, 0.04570381716, 0, 0, 0, -1],
+    [0.9989550114, 0.04570382088, 0, 0, 0, -1],
+    [1, 0, 0, 0, 1, 0],
+]
+out = [
+    [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2],
+    [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2],
+    [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2],
+    [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2],
+    [0.001, -0.037, 0.0, 0.0, 0.8, 0.8],
+]
+
+
 def test_contains_localizer_round():
 
-    assert DicomArchive._round_iop(im_arr).tolist() ==  out
+    assert DicomArchive._round_iop(im_arr).tolist() == out
+
 
 def test_dicom_tag_value_dict(mocker):
-    zip_mock = mocker.patch('utils.dicom.dicom_archive.zipfile')
-    mocker.patch('utils.dicom.dicom_archive.DicomArchive._validate')
-    mocker.patch('utils.dicom.dicom_archive.DicomArchive.initialize_dataset')
-    archive = DicomArchive('test','test2')
+    zip_mock = mocker.patch("utils.dicom.dicom_archive.zipfile")
+    mocker.patch("utils.dicom.dicom_archive.DicomArchive._validate")
+    mocker.patch("utils.dicom.dicom_archive.DicomArchive.initialize_dataset")
+    archive = DicomArchive("test", "test2")
 
-
-    tag_vals = mocker.patch.object(archive, 'dicom_tag_value_list')
+    tag_vals = mocker.patch.object(archive, "dicom_tag_value_list")
     tag_vals.return_value = im_arr
     ims = []
     for im in im_arr:
@@ -62,9 +82,7 @@ def test_dicom_tag_value_dict(mocker):
         ims.append(im_patch)
     archive.dataset_list = ims
 
-    rounded = archive.dicom_tag_value_dict('ImageOrientationPatient')
-    assert list(rounded.keys()) == [tuple(o) for o in np.unique(np.array(out),axis=0).tolist()]
-
-
-#def test_create_dicom_tag_value_dict_IOP():
-
+    rounded = archive.dicom_tag_value_dict("ImageOrientationPatient")
+    assert list(rounded.keys()) == [
+        tuple(o) for o in np.unique(np.array(out), axis=0).tolist()
+    ]

--- a/tests/unit_tests/test_dicom_archive.py
+++ b/tests/unit_tests/test_dicom_archive.py
@@ -37,6 +37,8 @@ def test_dicom_archive_class_validate():
             assert DicomArchive(not_dicom_path, extract_dir=temp_dir, validate=True)
         assert 'failed to parse DICOMs' in str(err.value)
 
-@pytest.mark.parametrize('raw,exp',[(-.0365001,-.036),[-.036,-.036]])
-def test_contains_localizer_round(raw,exp):
-    assert DicomArchive._apply_rounding([raw]) == (exp,)
+def test_contains_localizer_round():
+    im_arr = [[0.9989550114, 0.04570378363, 0, 0, 0, -1], [0.9989550114, 0.04570382088, 0, 0, 0, -1], [0.9989550114, 0.04570381716, 0, 0, 0, -1], [0.9989550114, 0.04570382088, 0, 0, 0, -1],[1, 0, 0, 0, 1, 0]]
+    out = [[-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [0.001, -0.037, 0.0, 0.0, 0.8, 0.8]]
+
+    assert DicomArchive._round_iop(im_arr).tolist() ==  out

--- a/tests/unit_tests/test_dicom_archive.py
+++ b/tests/unit_tests/test_dicom_archive.py
@@ -1,4 +1,5 @@
 import tempfile
+import numpy as np
 import os
 import pathlib
 import zipfile
@@ -7,6 +8,7 @@ import pytest
 from pydicom.data import get_testdata_files
 
 from utils.dicom.dicom_archive import DicomArchive
+from unittest.mock import MagicMock
 
 
 def test_dicom_archive_class_validate():
@@ -37,8 +39,32 @@ def test_dicom_archive_class_validate():
             assert DicomArchive(not_dicom_path, extract_dir=temp_dir, validate=True)
         assert 'failed to parse DICOMs' in str(err.value)
 
+
+im_arr = [[0.9989550114, 0.04570378363, 0, 0, 0, -1], [0.9989550114, 0.04570382088, 0, 0, 0, -1], [0.9989550114, 0.04570381716, 0, 0, 0, -1], [0.9989550114, 0.04570382088, 0, 0, 0, -1],[1, 0, 0, 0, 1, 0]]
+out = [[-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [0.001, -0.037, 0.0, 0.0, 0.8, 0.8]]
 def test_contains_localizer_round():
-    im_arr = [[0.9989550114, 0.04570378363, 0, 0, 0, -1], [0.9989550114, 0.04570382088, 0, 0, 0, -1], [0.9989550114, 0.04570381716, 0, 0, 0, -1], [0.9989550114, 0.04570382088, 0, 0, 0, -1],[1, 0, 0, 0, 1, 0]]
-    out = [[-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [-0.0, 0.009, 0.0, 0.0, -0.2, -0.2], [0.001, -0.037, 0.0, 0.0, 0.8, 0.8]]
 
     assert DicomArchive._round_iop(im_arr).tolist() ==  out
+
+def test_dicom_tag_value_dict(mocker):
+    zip_mock = mocker.patch('utils.dicom.dicom_archive.zipfile')
+    mocker.patch('utils.dicom.dicom_archive.DicomArchive._validate')
+    mocker.patch('utils.dicom.dicom_archive.DicomArchive.initialize_dataset')
+    archive = DicomArchive('test','test2')
+
+
+    tag_vals = mocker.patch.object(archive, 'dicom_tag_value_list')
+    tag_vals.return_value = im_arr
+    ims = []
+    for im in im_arr:
+        im_patch = MagicMock()
+        im_patch.header_dict.get.return_value = im
+        ims.append(im_patch)
+    archive.dataset_list = ims
+
+    rounded = archive.dicom_tag_value_dict('ImageOrientationPatient')
+    assert list(rounded.keys()) == [tuple(o) for o in np.unique(np.array(out),axis=0).tolist()]
+
+
+#def test_create_dicom_tag_value_dict_IOP():
+

--- a/utils/dicom/dicom_archive.py
+++ b/utils/dicom/dicom_archive.py
@@ -184,7 +184,11 @@ class DicomArchive:
             if tag_value:
                 if type(tag_value) == list:
                     if dicom_tag == 'ImageOrientationPatient':  # rounding a little to avoid dropping images
-                        # Subtract mean from value and round to specificied number of decimals
+                        # Subtract mean in order to prevent rounding errors close to the rounding cutoff.
+                        # around uses a cutoff of the decimal .5, so If we use a three decimal rounding, the 
+                        # cutoff is .0005, i.e. .0005 rounds down to 0.000, but .000501 rounds up to .001
+                        # Removing the mean before rounding reduces the likelihood that this could happen since
+                        # The mean should be very close to 0, and the localizer should be the only one that isn't at 0.
                         tag_value_key = tuple(
                             np.around(np.array(tag_value) - iop_means,
                             decimals=TOLERANCE_ON_ImageOrientationPatient).tolist())

--- a/utils/dicom/dicom_archive.py
+++ b/utils/dicom/dicom_archive.py
@@ -244,14 +244,19 @@ class DicomArchive:
             log.warning('Dicom ImageOrientationPatient tag missing, skipping localizer splitting')
             return embedded_localizer
 
-
+        # Implement round-up scheme, python's internal rounding method uses a round-to-even approach 
+        # https://stackoverflow.com/questions/18473563/python-incorrect-rounding-with-floating-point-numbers
+        # Implement a round-up approach by hand
+        def round_up(n, decimals=0):
+            mult = 10 ** decimals
+            return math.ceil(n * multiplier) / multiplier
         # Apply some rounding
         # NOTE: It has been observed that, in some series, ImageOrientationPatient might be
         # slightly varying between slices even though the patient orientation remains the same (uncertain root cause).
         # If strictly splitting on ImageOrientationPatient "uniqueness" it leads in wrongly creating multiple series.
         # Applying a certain rounding threshold fixes this issue.
         def apply_rounding(t):
-            return tuple(map(lambda x: round(float(x), TOLERANCE_ON_ImageOrientationPatient), t))
+            return tuple(map(lambda x: round_up(float(x), TOLERANCE_ON_ImageOrientationPatient), t))
         iop_tuple_list = list(map(apply_rounding, iop_tuple_list))
 
         image_count = len(iop_tuple_list)


### PR DESCRIPTION
Fix rounding issue that caused embedded localizers to be split incorrectly

* Remove mean across archive before rounding.
